### PR TITLE
Remove FLoops

### DIFF
--- a/src/Vlasiator.jl
+++ b/src/Vlasiator.jl
@@ -7,7 +7,6 @@ using UnPack
 using LinearAlgebra: ×, dot, ⋅, norm, I
 using Statistics: mean
 using EzXML
-using FLoops
 using Mmap: mmap
 using WriteVTK
 using LazyGrids: ndgrid

--- a/src/utility/rotation.jl
+++ b/src/utility/rotation.jl
@@ -3,7 +3,7 @@
 """
     rotateTensorToVectorZ(tensor, vector)
 
-Rotates `tensor` with a rotation matrix that aligns z-axis with `vector`.
+Rotates `tensor` with a rotation matrix that aligns the 3rd direction with `vector`.
 """
 function rotateTensorToVectorZ(tensor::AbstractMatrix{T}, v::AbstractVector{T}) where T
    unitz = SVector{3, T}(0.0, 0.0, 1.0)
@@ -32,52 +32,4 @@ function getRotationMatrix(v::AbstractVector, θ)
         cosθ+v[1]^2*tmp         v[1]*v[2]*tmp-v[3]*sinθ v[1]*v[3]*tmp+v[2]*sinθ;
         v[1]*v[2]*tmp+v[3]*sinθ cosθ+v[2]^2*tmp         v[2]*v[3]*tmp-v[1]*sinθ;
         v[1]*v[3]*tmp-v[2]*sinθ v[3]*v[2]*tmp+v[1]*sinθ cosθ+v[3]^2*tmp]
-end
-
-"""
-    getRotationB(B) -> SMatrix
-
-Obtain a rotation matrix with each column being a unit vector which is parallel (`v3`) and
-perpendicular (`v1,v2`) to the magnetic field `B`. The two perpendicular directions are
-chosen based on the reference vector of z-axis in the Cartesian coordinates.
-"""
-function getRotationB(B::AbstractVector{T}) where T
-   b = hypot(B[1], B[2], B[3])
-   R =
-      if B[3] / b ≈ -1.0 # B aligned with reference vector
-         SMatrix{3,3,T}([0.0 -1.0 0.0; 1.0 0.0 0.0; 0.0 0.0 1.0])
-      elseif B[3] / b ≈ 1.0 # B aligned with reference vector
-         SMatrix{3,3,T}([0.0 -1.0 0.0; 1.0 0.0 0.0; 0.0 0.0 1.0])
-      else
-         @warn "bug: not working correctly for general cases!"
-         v0 = SVector{3,T}(0.0, 0.0, 1.0) # reference vector
-         v3 = SVector{3,T}(B[1]/b, B[2]/b, B[3]/b) # unit vector along B
-         v1 = v0 × v3::SVector{3, T}
-         v2 = v3 × v1::SVector{3, T}
-
-         @SMatrix [v1[1] v2[1] v3[1]; v1[2] v2[2] v3[2]; v1[3] v2[3] v3[3]]
-      end
-   R
-end
-
-"""
-    rotateWithB(T, B) -> Matrix
-
-Rotate the tensor `T` with the 3rd direction aligned with `B`.
-See also: [`rotateWithB!`](@ref)
-"""
-function rotateWithB(T::AbstractMatrix, B::AbstractVector)
-   R = getRotationB(B)
-   R * T * R'
-end
-
-"""
-    rotateWithB!(T, B)
-
-Rotate the tensor `T` with the 3rd direction aligned with `B`.
-See also: [`rotateWithB`](@ref)
-"""
-function rotateWithB!(T::AbstractMatrix, B::AbstractVector)
-   R = getRotationB(B)
-   T[:] = R * T * R'
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,13 +176,6 @@ end
 
    if group in (:utility, :all)
       @testset "Rotation" begin
-         using LinearAlgebra
-         T = Diagonal([1.0, 2.0, 3.0])
-         B = [0.0, 1.0, 0.0]
-         Vlasiator.rotateWithB!(T, B)
-         @test T == Diagonal([1.0, 3.0, 2.0])
-         @test Vlasiator.rotateWithB(T, B) == Diagonal([1.0, 2.0, 3.0])
-
          v = fill(1/√3, 3)
          θ = π / 4
          R = Vlasiator.getRotationMatrix(v, θ)


### PR DESCRIPTION
Unexpected memory allocations within loops almost always indicate type instabilities. FLoops helps before because it creates some kind of function-barrier-like thing to the loops. As I apply function barriers directly, it is no longer needed for speed.

I also refactored the FS grid reading to reduce memory usage even further.