### PR TITLE
Reduce memory usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.dat
 *.vti
 *.vthb
+*.mem
 test*
 /benchmark/*.json
 /docs/build/

--- a/src/plot/plots.jl
+++ b/src/plot/plots.jl
@@ -17,15 +17,15 @@ using RecipesBase, Printf, UnPack
    elseif ndims(meta) == 2
       # Check if ecliptic or polar run
       if ncells[2] == 1 && ncells[3] != 1
-         plotrange = [coordmin[1], coordmax[1], coordmin[3], coordmax[3]]
-         sizes = [ncells[1], ncells[2]]
+         plotrange = (coordmin[1], coordmax[1], coordmin[3], coordmax[3])
+         sizes = (ncells[1], ncells[2])
          PLANE = "XZ"
-         axislabels = ['X', 'Z']
+         axislabels = ('X', 'Z')
       elseif ncells[3] == 1 && ncells[2] != 1
-         plotrange = [coordmin[1], coordmax[1], coordmin[2], coordmax[2]]
-         sizes = [ncells[1], ncells[2]]
+         plotrange = (coordmin[1], coordmax[1], coordmin[2], coordmax[2])
+         sizes = (ncells[1], ncells[2])
          PLANE = "XY"
-         axislabels = ['X', 'Y']
+         axislabels = ('X', 'Y')
       end
 
       x, y = Vlasiator.get_axis(axisunit, plotrange, sizes)

--- a/src/plot/pyplot.jl
+++ b/src/plot/pyplot.jl
@@ -82,17 +82,17 @@ function set_vector(meta::MetaVLSV, var, comp, axisunit::AxisUnit)
       v1_ = 1
       if occursin("y", comp)
          v2_ = 2
-         sizes = [ncells[1], ncells[2]]
-         plotrange = [coordmin[1], coordmax[1], coordmin[2], coordmax[2]]
+         sizes = (ncells[1], ncells[2])
+         plotrange = (coordmin[1], coordmax[1], coordmin[2], coordmax[2])
       else
          v2_ = 3
-         sizes = [ncells[1], ncells[3]]
-         plotrange = [coordmin[1], coordmax[1], coordmin[3], coordmax[3]]
+         sizes = (ncells[1], ncells[3])
+         plotrange = (coordmin[1], coordmax[1], coordmin[3], coordmax[3])
       end
    else
       v1_, v2_ = 2, 3
-      sizes = [ncells[2], ncells[3]]
-      plotrange = [coordmin[2], coordmax[2], coordmin[3], coordmax[3]]
+      sizes = (ncells[2], ncells[3])
+      plotrange = (coordmin[2], coordmax[2], coordmin[3], coordmax[3])
    end
 
    data = readvariable(meta, var)

--- a/src/utility/plot.jl
+++ b/src/utility/plot.jl
@@ -12,7 +12,7 @@ struct PlotArgs
    "data array size"
    sizes::Vector{Int}
    "plotting data range"
-   plotrange::Vector{Float32}
+   plotrange::Tuple{Float64, Float64, Float64, Float64}
    "cell IDs in the cut plane"
    idlist::Vector{Int}
    "mapping from original cell order to cut plane"
@@ -45,7 +45,7 @@ function set_args(meta::MetaVLSV, var, axisunit::AxisUnit; normal::Symbol=:none,
    end
 
    sizes = ncells[seq]
-   plotrange = [coordmin[seq[1]], coordmax[seq[1]], coordmin[seq[2]], coordmax[seq[2]]]
+   plotrange = (coordmin[seq[1]], coordmax[seq[1]], coordmin[seq[2]], coordmax[seq[2]])
    axislabels = ['X', 'Y', 'Z'][seq]
 
    if normal == :none


### PR DESCRIPTION
Suscipious memory allocations almost always indicate type instabilities. I used `julia --track-allocation=user` to scan through all the tests and greatly improved on memory usage.

For example, calculating rotated pressure tensor `Protated` is now 8x faster than before.