### PR TITLE
Update test data

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,7 +1,7 @@
 [testdata]
-git-tree-sha1 = "ba84cba7c11820a25d8ce35a29c680b6e12c655f"
+git-tree-sha1 = "88e414a79028fb2a89f5ce46bc9c2e308eab735d"
 lazy = true
 
     [[testdata.download]]
     url = "https://github.com/henry2004y/vlsv_data/raw/master/testdata.tar.gz"
-    sha256 = "1cea69c5695a3025d8b27661055bbea0828f4a6a00fd65347c13baa452bf1af0"
+    sha256 = "6ffdfd24b3096be18f16f3f9d773f3cca42b955c1cfb529f20c4c47cfc06d460"

--- a/src/vlsv/vlsvutility.jl
+++ b/src/vlsv/vlsvutility.jl
@@ -629,7 +629,7 @@ function fillmesh(meta::MetaVLSV, vars; verbose=false)
 
             fillcell!(ilvl, ids, ncells, maxamr, nLow, celldata[iv], data)
          end
-      else # max amr level
+      else # max refinement level
          for (iv, var) = enumerate(vars)
             verbose && @info "reading variable $var..."
             if startswith(var, "fg_")


### PR DESCRIPTION
We handle #38 in this PR:
* Adding pressure tensor to the 1D test data
* Adding tests for rotated pressure tensor, pressure and temperature anisotropies, and agyrotropy
* Making 1D test data smaller by saving only 2 VDF cells