### PR TITLE
Replace SVector with Tuple

### DIFF
--- a/src/Vlasiator.jl
+++ b/src/Vlasiator.jl
@@ -1,7 +1,7 @@
 module Vlasiator
 
 using Requires
-using StaticArrays
+using StaticArrays: SVector, @SMatrix
 using Printf: @sprintf
 using LinearAlgebra: ×, dot, ⋅, norm, normalize!
 using Statistics: mean

--- a/src/utility/plot.jl
+++ b/src/utility/plot.jl
@@ -37,22 +37,22 @@ function set_args(meta::MetaVLSV, var, axisunit::AxisUnit; normal::Symbol=:none,
    (;ncells, coordmin, coordmax) = meta
 
    if normal == :x
-      seq = @SVector [2,3]
+      seq = (2,3)
       dir = 1
    elseif normal == :y || (ncells[2] == 1 && ncells[3] != 1) # polar
-      seq = @SVector [1,3]
+      seq = (1,3)
       dir = 2
    elseif normal == :z || (ncells[3] == 1 && ncells[2] != 1) # ecliptic
-      seq = @SVector [1,2]
+      seq = (1,2)
       dir = 3
    else
       throw(ArgumentError("1D data detected. Please use 1D plot functions."))
    end
 
    plotrange = (coordmin[seq[1]], coordmax[seq[1]], coordmin[seq[2]], coordmax[seq[2]])
-   axislabels = ['X', 'Y', 'Z'][seq]
+   axislabels = ['X', 'Y', 'Z'][[seq...]]
    # Scale the sizes to the highest refinement level
-   sizes = ncells[seq] .* 2^meta.maxamr # data needs to be refined later
+   sizes = ncells[[seq...]] .* 2^meta.maxamr # data needs to be refined later
 
    if normal == :none
       idlist, indexlist = Int[], Int[]

--- a/src/utility/plot.jl
+++ b/src/utility/plot.jl
@@ -10,7 +10,7 @@ struct PlotArgs
    "Unit of spatial axis"
    axisunit::AxisUnit
    "data array size"
-   sizes::Vector{Int}
+   sizes::Tuple{Int64, Int64}
    "plotting data range"
    plotrange::Tuple{Float64, Float64, Float64, Float64}
    "cell IDs in the cut plane"
@@ -49,9 +49,10 @@ function set_args(meta::MetaVLSV, var, axisunit::AxisUnit; normal::Symbol=:none,
       throw(ArgumentError("1D data detected. Please use 1D plot functions."))
    end
 
-   sizes = ncells[seq]
    plotrange = (coordmin[seq[1]], coordmax[seq[1]], coordmin[seq[2]], coordmax[seq[2]])
    axislabels = ['X', 'Y', 'Z'][seq]
+   # Scale the sizes to the highest refinement level
+   sizes = ncells[seq] .* 2^meta.maxamr # data needs to be refined later
 
    if normal == :none
       idlist, indexlist = Int[], Int[]
@@ -60,9 +61,6 @@ function set_args(meta::MetaVLSV, var, axisunit::AxisUnit; normal::Symbol=:none,
          getslicecell(meta, sliceoffset, dir, coordmin[dir], coordmax[dir])
       end
    end
-
-   # Scale the sizes to the highest refinement level
-   sizes *= 2^meta.maxamr # data needs to be refined later
 
    unitstr = axisunit == RE ? L"$R_E$" : L"$m$"
    strx = axislabels[1]*"["*unitstr*"]"

--- a/src/utility/vector.jl
+++ b/src/utility/vector.jl
@@ -1,10 +1,10 @@
 """
-    curl(dx::AbstractVector, A::AbstractArray)
+    curl(dx, A::AbstractArray)
 
 Calculate 2nd order cell-centered ∇×A where `A` is a 4D array of size (3, nx, ny, nz) and
 `dx` is a vector of grid intervals in each dimension.
 """
-function curl(dx::AbstractVector, A::AbstractArray{T,N}) where {T,N}
+function curl(dx, A::AbstractArray{T,N}) where {T,N}
    @assert N == 4 && length(dx) == 3 "Input vector shall be indexed in 3D!"
 
    @views Ax, Ay, Az = A[1,:,:,:], A[2,:,:,:], A[3,:,:,:]
@@ -60,12 +60,12 @@ function curl(dx::AbstractVector, A::AbstractArray{T,N}) where {T,N}
 end
 
 """
-    gradient(dx::AbstractVector, A::AbstractArray)
+    gradient(dx, A::AbstractArray)
 
 Calculate 2nd order cell-centered ∇A where `A` is a 3D scalar array of size (nx, ny, nz)
 and `dx` is a vector of grid intervals in each dimension.
 """
-function gradient(dx::AbstractVector, A::AbstractArray{T,N}) where {T,N}
+function gradient(dx, A::AbstractArray{T,N}) where {T,N}
    @assert N == 3 && length(dx) == 3 "Input scalar shall be indexed in 3D!"
    @assert all(!=(1), size(A)) "Input scalar must be from 3D data!"
 
@@ -87,12 +87,12 @@ function gradient(dx::AbstractVector, A::AbstractArray{T,N}) where {T,N}
 end
 
 """
-    divergence(dx::AbstractVector, A::AbstractArray)
+    divergence(dx, A::AbstractArray)
 
 Calculate 2nd order cell-centered ∇⋅A where `A` is a 4D array of size (3, nx, ny, nz) and
 `dx` is a vector of grid intervals in each dimension.
 """
-function divergence(dx::AbstractVector, A::AbstractArray{T,N}) where {T,N}
+function divergence(dx, A::AbstractArray{T,N}) where {T,N}
    @assert N == 4 && length(dx) == 3 "Input vector shall be indexed in 3D!"
    @assert all(!=(1), size(A)) "Input vector must be from 3D data!"
 

--- a/src/utility/vector.jl
+++ b/src/utility/vector.jl
@@ -12,7 +12,7 @@ function curl(dx, A::AbstractArray{T,N}) where {T,N}
    B = zeros(T, size(A))
    @views Bx, By, Bz = B[1,:,:,:], B[2,:,:,:], B[3,:,:,:]
 
-   invdx = inv.(2*dx)
+   invdx = @. inv(2*dx)
 
    if any(==(1), size(A)) # 2Ds
       if size(A,4) == 1
@@ -70,7 +70,7 @@ function gradient(dx, A::AbstractArray{T,N}) where {T,N}
    @assert all(!=(1), size(A)) "Input scalar must be from 3D data!"
 
    B = zeros(T, 3, size(A)[1], size(A)[2], size(A)[3])
-   invdx = inv.(2*dx)
+   invdx = @. inv(2*dx)
    @views Bx, By, Bz = B[1,:,:,:], B[2,:,:,:], B[3,:,:,:]
 
    # 3D
@@ -100,7 +100,7 @@ function divergence(dx, A::AbstractArray{T,N}) where {T,N}
 
    B = zeros(T, size(A)[2:end])
 
-   invdx = inv.(2*dx)
+   invdx = @. inv(2*dx)
 
    @inbounds for k in 2:size(A,4)-1, j in 2:size(A,3)-1, i in 2:size(A,2)-1
       ∂Ax∂x = (-Ax[i-1,j,k] + Ax[i+1,j,k]) * invdx[1]

--- a/src/vlsv/vlsvreader.jl
+++ b/src/vlsv/vlsvreader.jl
@@ -5,11 +5,11 @@ include("vlsvvariables.jl")
 "Velocity mesh information."
 struct VMeshInfo
    "number of velocity blocks"
-   vblocks::SVector{3, Int64}
-   vblock_size::SVector{3, Int64}
-   vmin::SVector{3, Float64}
-   vmax::SVector{3, Float64}
-   dv::SVector{3, Float64}
+   vblocks::Tuple{Int64, Int64, Int64}
+   vblock_size::Tuple{Int64, Int64, Int64}
+   vmin::Tuple{Float64, Float64, Float64}
+   vmax::Tuple{Float64, Float64, Float64}
+   dv::Tuple{Float64, Float64, Float64}
 end
 
 "Variable information from the VLSV footer."
@@ -38,11 +38,11 @@ struct MetaVLSV
    time::Float64
    maxamr::Int64
    hasvdf::Bool
-   ncells::SVector{3, Int64}
-   block_size::SVector{3, Int64}
-   coordmin::SVector{3, Float64}
-   coordmax::SVector{3, Float64}
-   dcoord::SVector{3, Float64}
+   ncells::Tuple{Int64, Int64, Int64}
+   block_size::Tuple{Int64, Int64, Int64}
+   coordmin::Tuple{Float64, Float64, Float64}
+   coordmax::Tuple{Float64, Float64, Float64}
+   dcoord::Tuple{Float64, Float64, Float64}
    species::Vector{String}
    meshes::Dict{String, VMeshInfo}
 end
@@ -67,9 +67,8 @@ end
 function Base.show(io::IO, vmesh::VMeshInfo)
    println(io, "vblocks: ", vmesh.vblocks)
    println(io, "vblock size: ", vmesh.vblock_size)
-   println(io, "vx range: ", vmesh.vmin[1], ":", vmesh.dv[1], ":", vmesh.vmax[1])
-   println(io, "vy range: ", vmesh.vmin[2], ":", vmesh.dv[2], ":", vmesh.vmax[2])
-   println(io, "vz range: ", vmesh.vmin[3], ":", vmesh.dv[3], ":", vmesh.vmax[3])
+   foreach((vmin,dv,vmax,comp) -> println(io, "v$comp range: ", vmin, ":", dv, ":", vmax),
+      vmesh.vmin, vmesh.dv, vmesh.vmax, 'x':'z')
 end
 
 "Return the XML footer of opened VLSV file."
@@ -162,15 +161,12 @@ function load(file::AbstractString)
    nodeCoordsY = readmesh(fid, footer, "SpatialGrid", "MESH_NODE_CRDS_Y")::Vector{Float64}
    nodeCoordsZ = readmesh(fid, footer, "SpatialGrid", "MESH_NODE_CRDS_Z")::Vector{Float64}
 
-   @inbounds ncells = SVector(bbox[1], bbox[2], bbox[3])
-   @inbounds block_size = SVector(bbox[4], bbox[5], bbox[6])
-   @inbounds coordmin = SVector(nodeCoordsX[begin], nodeCoordsY[begin], nodeCoordsZ[begin])
-   @inbounds coordmax = SVector(nodeCoordsX[end], nodeCoordsY[end], nodeCoordsZ[end])
+   @inbounds ncells = (bbox[1], bbox[2], bbox[3])
+   @inbounds block_size = (bbox[4], bbox[5], bbox[6])
+   @inbounds coordmin = (nodeCoordsX[begin], nodeCoordsY[begin], nodeCoordsZ[begin])
+   @inbounds coordmax = (nodeCoordsX[end], nodeCoordsY[end], nodeCoordsZ[end])
 
-   dcoord = SVector(
-      (coordmax[1] - coordmin[1]) / ncells[1],
-      (coordmax[2] - coordmin[2]) / ncells[2],
-      (coordmax[3] - coordmin[3]) / ncells[3])
+   dcoord = ntuple(i -> (coordmax[i] - coordmin[i]) / ncells[i], Val(3))
 
    meshes = Dict{String, VMeshInfo}()
 
@@ -188,40 +184,31 @@ function load(file::AbstractString)
          nodeCoordsX = readmesh(fid, footer, popname, "MESH_NODE_CRDS_X")::Vector{Float64}
          nodeCoordsY = readmesh(fid, footer, popname, "MESH_NODE_CRDS_Y")::Vector{Float64}
          nodeCoordsZ = readmesh(fid, footer, popname, "MESH_NODE_CRDS_Z")::Vector{Float64}
-         vblocks = SVector(bbox[1], bbox[2], bbox[3])
-         vblock_size = SVector(bbox[4], bbox[5], bbox[6])
-         vmin = SVector(nodeCoordsX[begin], nodeCoordsY[begin], nodeCoordsZ[begin])
-         vmax = SVector(nodeCoordsX[end], nodeCoordsY[end], nodeCoordsZ[end])
-         dv = SVector(
-            (vmax[1] - vmin[1]) / vblocks[1] / vblock_size[1],
-            (vmax[2] - vmin[2]) / vblocks[2] / vblock_size[2],
-            (vmax[3] - vmin[3]) / vblocks[3] / vblock_size[3])
+         vblocks = (bbox[1], bbox[2], bbox[3])
+         vblock_size = (bbox[4], bbox[5], bbox[6])
+         vmin = (nodeCoordsX[begin], nodeCoordsY[begin], nodeCoordsZ[begin])
+         vmax = (nodeCoordsX[end], nodeCoordsY[end], nodeCoordsZ[end])
+         dv = ntuple(i -> (vmax[i] - vmin[i]) / vblocks[i] / vblock_size[i], Val(3))
       else
          popname = "avgs"
 
          if "vxblocks_ini" in getindex.(findall("//PARAMETER", footer), "name")
             # In VLSV before 5.0 the mesh is defined with parameters.
-            vblocks = SVector(
-               readparameter(fid, footer, "vxblocks_ini"),
-               readparameter(fid, footer, "vyblocks_ini"),
-               readparameter(fid, footer, "vzblocks_ini"))
-            vblock_size = SVector(4, 4, 4)
-            vmin = SVector(
-               readparameter(fid, footer, "vxmin"),
-               readparameter(fid, footer, "vymin"),
-               readparameter(fid, footer, "vzmin") )
-            vmax = SVector(
-               readparameter(fid, footer, "vxmax"),
-               readparameter(fid, footer, "vymax"),
-               readparameter(fid, footer, "vzmax") )
-            dv = SVector{3}(@. (vmax - vmin) / vblocks / vblock_size)
+            vblocks_str = ("vxblocks_ini", "vyblocks_ini", "vzblocks_ini")
+            vmin_str = ("vxmin", "vymin", "vzmin")
+            vmax_str = ("vxmax", "vymax", "vzmax")
+            vblocks = ntuple(i -> readparameter(fid, footer, vblocks_str[i]), Val(3))
+            vblock_size = (4, 4, 4)
+            vmin = ntuple(i -> readparameter(fid, footer, vmin_str[i]), Val(3))
+            vmax = ntuple(i -> readparameter(fid, footer, vmax_str[i]), Val(3))
+            dv = ntuple(i -> (vmax[i] - vmin[i]) / vblocks[i] / vblock_size[i], Val(3))
          else
             # No velocity space info, e.g., file not written by Vlasiator
-            vblocks = SVector(0, 0, 0)
-            vblock_size = SVector(4, 4, 4)
-            vmin = SVector(0, 0, 0)
-            vmax = SVector(0, 0, 0)
-            dv = SVector(1, 1, 1)
+            vblocks = (0, 0, 0)
+            vblock_size = (4, 4, 4)
+            vmin = (0, 0, 0)
+            vmax = (0, 0, 0)
+            dv = (1, 1, 1)
          end
       end
 
@@ -337,7 +324,7 @@ function readvariable(meta::MetaVLSV, var, sorted::Bool=true)
    raw = readvector(fid, footer, var, "VARIABLE")
 
    if startswith(var, "fg_") # fsgrid
-      bbox = SVector{6}(readmesh(fid, footer, "fsgrid", "MESH_BBOX")::Vector{Int})
+      bbox = readmesh(fid, footer, "fsgrid", "MESH_BBOX")::Vector{Int}
       # Determine fsgrid domain decomposition
       nIORanks = readparameter(meta, "numWritingRanks")::Int32
 
@@ -413,29 +400,20 @@ function _fillFGordered!(dataOrdered, raw, fgDecomposition, nIORanks, bbox)
          (i - 1) ÷ fgDecomposition[3] % fgDecomposition[2],
          (i - 1) % fgDecomposition[3] ]
 
-      lsize = SVector(calcLocalSize(bbox[1], fgDecomposition[1], xyz[1]),
-                      calcLocalSize(bbox[2], fgDecomposition[2], xyz[2]),
-                      calcLocalSize(bbox[3], fgDecomposition[3], xyz[3]) )
-
-      lstart = SVector(calcLocalStart(bbox[1], fgDecomposition[1], xyz[1]),
-                       calcLocalStart(bbox[2], fgDecomposition[2], xyz[2]),
-                       calcLocalStart(bbox[3], fgDecomposition[3], xyz[3]) )
-
-      offsetnext = offsetnow + lsize[1]*lsize[2]*lsize[3]
-
-      lend = lstart + lsize .- 1
+      lsize = ntuple(i -> calcLocalSize(bbox[i], fgDecomposition[i], xyz[i]), Val(3))
+      lstart = ntuple(i -> calcLocalStart(bbox[i], fgDecomposition[i], xyz[i]), Val(3))
+      offsetnext = offsetnow + prod(lsize)
+      lend = @. lstart + lsize - 1
+      lrange = map((x,y)->x:y, lstart, lend)
       # Reorder data
       if ndims(raw) > 1
-         ldata = raw[:,offsetnow:offsetnext-1]
-         ldata = reshape(ldata, size(raw,1), lsize[1], lsize[2], lsize[3])
+         ldata = reshape(raw[:,offsetnow:offsetnext-1], size(raw,1), lsize...)
 
-         dataOrdered[:,lstart[1]:lend[1],lstart[2]:lend[2],lstart[3]:lend[3]] =
-            ldata
+         dataOrdered[:,lrange...] = ldata
       else
-         ldata = raw[offsetnow:offsetnext-1]
-         ldata = reshape(ldata, lsize[1], lsize[2], lsize[3])
+         ldata = reshape(raw[offsetnow:offsetnext-1], lsize...)
 
-         dataOrdered[lstart[1]:lend[1],lstart[2]:lend[2],lstart[3]:lend[3]] = ldata
+         dataOrdered[lrange...] = ldata
       end
       offsetnow = offsetnext
    end
@@ -446,7 +424,7 @@ end
 
 "Return 2d scalar/vector data. Nonpublic since it won't work with DCCRG AMR."
 function getdata2d(meta::MetaVLSV, var)
-   @assert ndims(meta) == 2 "2D outputs required."
+   ndims(meta) == 2 || @error "2D outputs required."
    sizes = filter(!=(1), meta.ncells)
    data = readvariable(meta, var)
    data = ndims(data) == 1 ?
@@ -460,7 +438,7 @@ end
 # Optimize decomposition of this grid over the given number of processors.
 # Reference: fsgrid.hpp
 function getDomainDecomposition(globalsize, nprocs)
-   domainDecomp = SVector(1, 1, 1)
+   domainDecomp = (1, 1, 1)
    minValue = typemax(Int)
 
    @inbounds for i = 1:min(nprocs, globalsize[1])
@@ -484,7 +462,7 @@ function getDomainDecomposition(globalsize, nprocs)
 
             if i * j * k == nprocs && v < minValue
                minValue = v
-               domainDecomp = SVector(i, j, k)
+               domainDecomp = (i, j, k)
             end
          end
       end

--- a/src/vlsv/vlsvreader.jl
+++ b/src/vlsv/vlsvreader.jl
@@ -395,10 +395,10 @@ function _fillFGordered!(dataOrdered, raw, fgDecomposition, nIORanks, bbox)
    offsetnow = 1
 
    @inbounds @views for i = 1:nIORanks
-      xyz = SA[
+      xyz = (
          (i - 1) ÷ fgDecomposition[3] ÷ fgDecomposition[2],
          (i - 1) ÷ fgDecomposition[3] % fgDecomposition[2],
-         (i - 1) % fgDecomposition[3] ]
+         (i - 1) % fgDecomposition[3] )
 
       lsize = ntuple(i -> calcLocalSize(bbox[i], fgDecomposition[i], xyz[i]), Val(3))
       lstart = ntuple(i -> calcLocalStart(bbox[i], fgDecomposition[i], xyz[i]), Val(3))

--- a/src/vlsv/vlsvutility.jl
+++ b/src/vlsv/vlsvutility.jl
@@ -124,7 +124,7 @@ function getchildren(meta::MetaVLSV, cid::Integer)
    iz *= 2
 
    nchildren = 2^ndims(meta)
-   cid = @MVector zeros(Int, nchildren)
+   cid = zeros(Int, nchildren)
    # get the first cell ID on the finer level
    cid1st += ncell*8^mylvl
    ix_, iy_ = (ix, ix+1), (iy, iy+1)
@@ -169,7 +169,7 @@ function getsiblings(meta::MetaVLSV, cid::Integer)
    iz, iz1 = minmax(iz, iz1)
 
    nsiblings = 2^ndims(meta)
-   cid = @MVector zeros(Int, nsiblings)
+   cid = zeros(Int, nsiblings)
    ix_, iy_ = (ix, ix1), (iy, iy1)
    iz_ = zcell != 1 ? (iz, iz1) : iz
    for (n,i) in enumerate(Iterators.product(ix_, iy_, iz_))
@@ -465,8 +465,8 @@ function getcellinline(meta::MetaVLSV, point1, point2)
    ϵ = eps(Float32)
    unit_vector = @. (point2 - point1) / $norm(point2 - point1 + ϵ)
    p = point1
-   coef_min = MVector(0.0, 0.0, 0.0)
-   coef_max = MVector(0.0, 0.0, 0.0)
+   coef_min = [0.0, 0.0, 0.0]
+   coef_max = [0.0, 0.0, 0.0]
 
    while true
       cid = getcell(meta, p)
@@ -711,9 +711,9 @@ function fillmesh(meta::MetaVLSV, vars; verbose=false)
    nvarvg = findall(!startswith("fg_"), vars)
    nv = length(vars)
    T = Vector{DataType}(undef, nv)
-   offset = @MVector zeros(Int, nv)
-   arraysize = @MVector zeros(Int, nv)
-   vsize  = @MVector zeros(Int, nv)
+   offset = zeros(Int, nv)
+   arraysize = zeros(Int, nv)
+   vsize  = zeros(Int, nv)
    @inbounds for i = 1:nv
       T[i], offset[i], arraysize[i], _, vsize[i] =
          getObjInfo(footer, vars[i], "VARIABLE", "name")
@@ -879,7 +879,7 @@ function write_vtk(meta::MetaVLSV; vars=[""], ascii=false, maxamronly=false, ver
          link!(xBlock, AttributeNode("spacing", spacing_str))
          xDataSet = addelement!(xBlock, "DataSet")
          link!(xDataSet, AttributeNode("index", "0"))
-         amr_box = SA[0, ncells[1]*2^i-1, 0, ncells[2]*2^i-1, 0, ncells[3]*2^i-1]
+         amr_box = (0, ncells[1]*2^i-1, 0, ncells[2]*2^i-1, 0, ncells[3]*2^i-1)
          box_str = @sprintf("%d %d %d %d %d %d", amr_box[1], amr_box[2], amr_box[3],
             amr_box[4], amr_box[5], amr_box[6])
          link!(xDataSet, AttributeNode("amr_box", box_str))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,7 +59,7 @@ end
          loc = [2.0, 0.0, 0.0]
          id = getcell(meta, loc)
          coords = getcellcoordinates(meta, id)
-         @test coords == [3.0, 0.0, 0.0]
+         @test coords == (3.0, 0.0, 0.0)
          @test readvariable(meta, "proton/vg_rho", id)[1] == 1.2288102f0
          # ID in a line
          point1 = [-4.0, 0.0, 0.0]
@@ -77,14 +77,14 @@ end
          # velocity space reading
          vcellids, vcellf = readvcells(meta, 5; species="proton")
          V = getvcellcoordinates(meta, vcellids; species="proton")
-         @test V[end] == Float32[2.45, 1.95, 1.95]
+         @test V[end] == (2.45f0, 1.95f0, 1.95f0)
          @test_throws ArgumentError readvcells(meta, 2)
          f = Vlasiator.flatten(meta.meshes["proton"], vcellids, vcellf)
          @test f[CartesianIndex(26, 20, 20)] == 85.41775f0
          @test getdensity(meta, f) ≈ 1.8255334f0
          @test getdensity(meta, vcellids, vcellf) ≈ 1.8255334f0
-         @test getvelocity(meta, f) ≈ [1.0f0, 0.0f0, 0.0f0] rtol=3e-3
-         @test getvelocity(meta, vcellids, vcellf) ≈ [1.0f0, 0.0f0, 0.0f0] rtol=3e-3
+         @test getvelocity(meta, f)[1] ≈ 1.0f0 rtol=3e-3
+         @test getvelocity(meta, vcellids, vcellf)[1] ≈ 1.0f0 rtol=3e-3
          @test getpressure(meta, f) ≈ zeros(Float32, 6) atol=1e-16
          @test getmaxwellianity(meta, f) ≈ 5.741325243685855 rtol=1e-4
 


### PR DESCRIPTION
My usage of `SVector` is uncessary in most cases since the variables are constant parameters. Removing the usage of `SVector` and using `Tuple` directly is faster.