### PR TITLE
Splitting Julia calling from Python doc

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,6 +15,7 @@ makedocs(;
     pages=[
         "Home" => "index.md",
         "User Guide" => "manual.md",
+        "Calling from Python" => "python.md",
         "Gallery" => "gallery.md",
         "API Reference" => "internal.md",
         "Contributing" => "contributing.md",

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -392,39 +392,6 @@ timestamps, speed = readlog(file)
 
 See a live example at [demo_log.jl](https://github.com/henry2004y/Vlasiator.jl/tree/master/examples/demo_log.jl).
 
-## Calling from Python
-
-It is possible to call this package directly from Python with the aid of [PyJulia](https://pyjulia.readthedocs.io/en/latest/).
-Following the installation steps described in the manual[^3], and then inside Python REPL:
-
-```
-# Handling initialization issue for Conda
-from julia.api import Julia
-jl = Julia(compiled_modules=False)
-
-from julia import Vlasiator
-file = "bulk1.0001000.vlsv"
-meta = Vlasiator.load(file)
-var = "proton/vg_rho"
-data = Vlasiator.readvariable(meta, var)
-```
-
-To run a Julia script in Python,
-
-```
-# Handling initialization issue for Conda
-from julia.api import Julia
-jl = Julia(compiled_modules=False)
-jl.eval('include("examples/demo_2dplot_pyplot.jl")')
-import matplotlib.pyplot as plt
-plt.show()
-```
-
-!!! note
-    This approach is for you to have a taste of the package with a Python frontend. The workaround shown above for handling the static python libraries makes it slow for regular use. An alternative solution would be creating system images, but as of Julia 1.6 the user experience is not smooth. For better integrated experience with its full power, it is recommended to use the package inside Julia.
-
-[^3]: For Debian-based Linux distributions, it gets a little bit tricky. Please refer to [Troubleshooting](https://pyjulia.readthedocs.io/en/latest/troubleshooting.html) for details.
-
 ## Examples
 
 There is a list of complete [examples](https://github.com/henry2004y/Vlasiator.jl/tree/master/examples) about:

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -10,11 +10,20 @@ JuliaCall will link to the first Julia version in the system path. If Vlasiator.
 ```python
 from juliacall import Main as jl
 jl.seval("using Vlasiator")
-file = "bulk.2d.vlsv"
+file = "bulk.1d.vlsv"
 meta = jl.load(file)
 ```
 
 Matplotlib can then be used to visualize the data.
+
+```python
+from matplotlib import pyplot as plt
+import numpy as np
+rho = jl.readvariable(meta, "proton/vg_rho")
+x = np.arange(meta.coordmin[0], meta.coordmax[0], meta.dcoord[0])
+plt.plot(x, rho)
+plt.show()
+```
 
 ## PyJulia
 

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -1,0 +1,50 @@
+# Interoperability Between Julia and Python
+
+There are currently two ways to call Julia from Python and vice versa.
+
+## JuliaCall
+
+Vlasiator.jl can be called from Python via [JuliaCall](https://cjdoris.github.io/PythonCall.jl/dev/juliacall/).
+JuliaCall will link to the first Julia version in the system path. If Vlasiator.jl has been installed, we can use it directly; otherwise we need to state it in the [juliacalldeps.json](https://cjdoris.github.io/PythonCall.jl/dev/juliacall/#juliacalldeps.json) file.
+
+```python
+from juliacall import Main as jl
+jl.seval("using Vlasiator")
+file = "bulk.2d.vlsv"
+meta = jl.load(file)
+```
+
+Matplotlib can then be used to visualize the data.
+
+## PyJulia
+
+Vlasiator.jl can also be called from Python with the aid of [PyJulia](https://pyjulia.readthedocs.io/en/latest/).
+Following the installation steps described in the manual[^1], and then inside Python REPL:
+
+```python
+# Handling initialization issue for Conda
+from julia.api import Julia
+jl = Julia(compiled_modules=False)
+
+from julia import Vlasiator
+file = "bulk1.0001000.vlsv"
+meta = Vlasiator.load(file)
+var = "proton/vg_rho"
+data = Vlasiator.readvariable(meta, var)
+```
+
+To run a Julia script in Python,
+
+```python
+# Handling initialization issue for Conda
+from julia.api import Julia
+jl = Julia(compiled_modules=False)
+jl.eval('include("examples/demo_2dplot_pyplot.jl")')
+import matplotlib.pyplot as plt
+plt.show()
+```
+
+!!! note
+    This approach is for you to have a taste of the package with a Python frontend. The workaround shown above for handling the static python libraries makes it slow for regular use. An alternative solution would be creating system images, but as of Julia 1.6 the user experience is not smooth. For better integrated experience with its full power, it is recommended to use the package inside Julia.
+
+[^1]: For Debian-based Linux distributions, it gets a little bit tricky. Please refer to [Troubleshooting](https://pyjulia.readthedocs.io/en/latest/troubleshooting.html) for details.


### PR DESCRIPTION
First we need to separate the Julia calling from Python section from the main user manual section.
Then we need to decide if we want one package or a completely new Python wrapper package for Vlasiator.jl