### PR TITLE
Refactoring VDF computations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Vlasiator"
 uuid = "7d2ba682-ad6e-4e20-80d9-3f2d4a610bb4"
 authors = ["Hongyang Zhou <hyzhou@umich.edu>"]
-version = "0.9.12"
+version = "0.9.13"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -161,25 +161,29 @@ We can also calculate the plasma moments from the saved VLSV velocity space dist
 ```
 # VDF cell indexes and values, with sparsity
 vcellids, vcellf = readvcells(meta, cellid; species="proton")
-# Recover the full VDF space
-f = Vlasiator.flatten(meta.meshes["proton"], vcellids, vcellf)
 
-getdensity(meta, f)
 getdensity(meta, vcellids, vcellf)
 
-getvelocity(meta, f)
 getvelocity(meta, vcellids, vcellf)
 
-getpressure(meta, f) # only support full VDF for now
+getvelocity(meta, vcellids, vcellf)
 ```
 
 Some useful quantities like non-Maxwellianity may be of interest. Currently we have implemented a monitor quantity named "Maxwellianity", which is defined as ``-ln \big[ 1/(2n) \int |f(v) - g(v)| dv \big]``, where n is the density, f(vᵢ) is the actual VDF value at velocity cell i, and g(vᵢ) is the analytical Maxwellian (or strictly speaking, normal) distribution with the same density, bulk velocity and scalar pressure as f.
 
 ```
-getmaxwellianity(meta, f)
+getmaxwellianity(meta, vcellids, vcellf)
 ```
 
 The value ranges from [0, +∞], with 0 meaning not Maxwellian-distributed at all, and +∞ a perfect Maxwellian distribution.
+
+Sometimes it may be useful to recover the full 3D array of VDFs:
+
+```
+f = Vlasiator.reconstruct(meta.meshes["proton"], vcellids, vcellf)
+```
+
+However, usually in practice there would be only about 1% nonzero values. The moments and maxwellianity calculations above all have an alternative form of using reconstructed VDFs as inputs.
 
 ## Plotting
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,14 +96,18 @@ end
          V = getvcellcoordinates(meta, vcellids; species="proton")
          @test V[end] == (2.45f0, 1.95f0, 1.95f0)
          @test_throws ArgumentError readvcells(meta, 2)
-         f = Vlasiator.flatten(meta.meshes["proton"], vcellids, vcellf)
+         vcids = Vlasiator.reorder(meta.meshes["proton"], vcellids, vcellf)
+         @test vcids[5] == 0x00000029
+         f = Vlasiator.reconstruct(meta.meshes["proton"], vcellids, vcellf)
          @test f[CartesianIndex(26, 20, 20)] == 85.41775f0
          @test getdensity(meta, f) ≈ 1.8255334f0
          @test getdensity(meta, vcellids, vcellf) ≈ 1.8255334f0
          @test getvelocity(meta, f)[1] ≈ 1.0f0 rtol=3e-3
          @test getvelocity(meta, vcellids, vcellf)[1] ≈ 1.0f0 rtol=3e-3
          @test getpressure(meta, f) ≈ zeros(Float32, 6) atol=1e-16
+         @test getpressure(meta, vcellids, vcellf) ≈ zeros(Float32, 6) atol=1e-16
          @test getmaxwellianity(meta, f) ≈ 5.741325243685855 rtol=1e-4
+         @test getmaxwellianity(meta, vcellids, vcellf) ≈ 5.741325243685855 rtol=1e-4
 
          # AMR data reading, DCCRG grid
          metaAMR = meta3


### PR DESCRIPTION
1. Allow direct fast moment and Maxwellianity calculations from raw `vcellids` and `vcellf`.
2. Rename `flatten` to `reconstruct`, to make it more consistent with the general concepts.
3. Add `reorder` to directly compute the ordering in regular Cartesian velocity space.
4. Modify the doc accordingly.

These are aimed at handling #79.