### PR TITLE
Add downsampling and upsampling methods

### DIFF
--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -81,6 +81,25 @@ var_extract = readvariable(meta, "VA", cellids)
 extractsat(files, var, id)
 ```
 
+- Downsample field solver variable to DCCRG grid
+
+```julia
+Vlasiator.downsample_fg(meta, "fg_e")
+```
+
+- Upsample DCCRG variable to field solver grid
+
+```julia
+data = Vlasiator.read_variable_as_fg(meta, "proton/vg_rho")
+# Equivalent to the above, but faster
+data = let
+   tmp = Vlasiator.fillmesh(meta, ["proton/vg_rho"]; maxamronly=true)[1][1][1]
+   reshape(tmp, size(tmp)[2:end])
+end
+```
+
+This is useful when corresponding DCCRG variables are not saved, or a uniform mesh is required for further analysis.
+
 - Compare VLSV files
 
 One may want to check if two vlsv files are identical. This is tricky because

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -313,6 +313,13 @@ end
          sha_str = bytes2hex(open(sha1, "bulk.amr_3.vti"))
          @test sha_str == "8a2bb0a15c5dcc329f88821036df840a86eef9d5"
 
+         @test Vlasiator.downsample_fg(meta, "fg_e")[1,3] == 7.5771624f-7
+         data = let
+            tmp = Vlasiator.fillmesh(meta, ["proton/vg_rho"]; maxamronly=true)[1][1][1]
+            reshape(tmp, size(tmp)[2:end])
+         end
+         @test Vlasiator.read_variable_as_fg(meta, "proton/vg_rho") == data
+
          # Selected region
          write_vtk(meta, vars=["proton/vg_rho"], maxamronly=true, box=
             [meta.coordmin[1], meta.coordmax[1], 0, meta.coordmax[2], 0, meta.coordmax[3]])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -302,6 +302,24 @@ end
       end
    end
 
+   if group in (:sample, :all)
+      @testset "Sampling" begin
+         meta = meta3 # amr
+
+         @test Vlasiator.downsample_fg(meta, "fg_e")[1,3] == 7.5771624f-7
+         coords = Vlasiator.SVector(100.0,200.0, 3e8)
+         @test_throws ErrorException Vlasiator.get_fg_indices(meta, coords)
+
+         data = let
+            tmp = Vlasiator.fillmesh(meta, ["proton/vg_rho"]; maxamronly=true)[1][1][1]
+            reshape(tmp, size(tmp)[2:end])
+         end
+         @test Vlasiator.read_variable_as_fg(meta, "proton/vg_rho") == data
+         @test Vlasiator.read_variable_as_fg(meta, "proton/vg_v")[1,18,8,8] == 106991.59f0
+
+      end
+   end
+
    if group in (:vtk, :all)
       @testset "VTK" begin
          meta = meta2 # no amr
@@ -312,13 +330,6 @@ end
          write_vtk(meta, vars=["proton/vg_rho", "fg_b", "proton/vg_v"])
          sha_str = bytes2hex(open(sha1, "bulk.amr_3.vti"))
          @test sha_str == "8a2bb0a15c5dcc329f88821036df840a86eef9d5"
-
-         @test Vlasiator.downsample_fg(meta, "fg_e")[1,3] == 7.5771624f-7
-         data = let
-            tmp = Vlasiator.fillmesh(meta, ["proton/vg_rho"]; maxamronly=true)[1][1][1]
-            reshape(tmp, size(tmp)[2:end])
-         end
-         @test Vlasiator.read_variable_as_fg(meta, "proton/vg_rho") == data
 
          # Selected region
          write_vtk(meta, vars=["proton/vg_rho"], maxamronly=true, box=


### PR DESCRIPTION
This is a successor of #82 to handle #101, which implements the method `downsample_fg` for converting large field solver variables arrays to small DCCRG arrays and vice versa. The upsampling method `read_variable_as_fg` is equivalent to part of the functionalities provided by `fillmesh`, which is shorter but less performant.