### PR TITLE
Xml parser

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,28 +5,28 @@ version = "0.10.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 LazyGrids = "7031d0ef-c40d-4431-b2f8-61a8d2f650db"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
+XML = "72c71f33-b9b6-44de-8c94-c961784809e2"
 
 [compat]
-EzXML = "1.1"
 LaTeXStrings = "1.2"
 LazyGrids = "0.4, 0.5"
 Parsers = "2.4"
-RecipesBase = "1.1"
 PrecompileTools = "1.0"
+RecipesBase = "1.1"
 StaticArrays = "1.2"
 WriteVTK = "1.9"
+XML = "0.2"
 julia = "1.7"
 
 [extras]

--- a/src/Vlasiator.jl
+++ b/src/Vlasiator.jl
@@ -4,7 +4,7 @@ using StaticArrays: SVector, @SVector, SMatrix, @SMatrix
 using Printf: @sprintf
 using LinearAlgebra: ×, dot, ⋅, norm, normalize, normalize!
 using Statistics: mean
-using XML
+using XML: Node, LazyNode, Element, Document, children, tag, attributes, value, write
 using Mmap: mmap
 using WriteVTK
 using LazyGrids: ndgrid

--- a/src/Vlasiator.jl
+++ b/src/Vlasiator.jl
@@ -4,7 +4,7 @@ using StaticArrays: SVector, @SVector, SMatrix, @SMatrix
 using Printf: @sprintf
 using LinearAlgebra: ×, dot, ⋅, norm, normalize, normalize!
 using Statistics: mean
-using EzXML
+using XML
 using Mmap: mmap
 using WriteVTK
 using LazyGrids: ndgrid

--- a/src/vlsv/vlsvreader.jl
+++ b/src/vlsv/vlsvreader.jl
@@ -1,6 +1,6 @@
 # VLSV reader in Julia
 
-const NodeVector = SubArray{EzXML.Node, 1, Vector{EzXML.Node}, Tuple{UnitRange{Int64}},
+const NodeVector = SubArray{XML.LazyNode, 1, Vector{XML.LazyNode}, Tuple{UnitRange{Int64}},
    true}
 
 "Velocity mesh information."
@@ -96,7 +96,9 @@ end
    # Obtain the offset of the XML
    offset = read(fid, Int)
    seek(fid, offset)
-   footer = read(fid, String) |> parsexml |> root
+   #footer = read(fid, String) |> parsexml |> root
+   str = read(fid, String)
+   footer = parse(str, LazyNode)
 end
 
 @inline function getdatatype(datatype::Symbol, datasize::Int)
@@ -112,17 +114,18 @@ end
       end
 end
 
-function getvarinfo(nodevar::AbstractVector{EzXML.Node}, name::String)
+function getvarinfo(nodevar::NodeVector, name::String)
    local arraysize, datasize, datatype, vectorsize, offset
    isFound = false
 
-   for var in nodevar
+   for nv in nodevar
+      var = XML.attributes(nv)
       if var["name"] == name
          arraysize = Parsers.parse(Int, var["arraysize"])
          datasize = Parsers.parse(Int, var["datasize"])
          datatype = Symbol(var["datatype"])
          vectorsize = Parsers.parse(Int, var["vectorsize"])
-         offset = Parsers.parse(Int, nodecontent(var))
+         offset = Parsers.parse(Int, value(nv[1]))
          isFound = true
          break
       end
@@ -140,10 +143,11 @@ end
    isFound = false
 
    for p in nodeparam
-      if p["name"] == name
-         datasize = Parsers.parse(Int, p["datasize"])
-         datatype = Symbol(p["datatype"])
-         offset = Parsers.parse(Int, nodecontent(p))
+      param = XML.attributes(p)
+      if param["name"] == name
+         datasize = Parsers.parse(Int, param["datasize"])
+         datatype = Symbol(param["datatype"])
+         offset = Parsers.parse(Int, value(p[1]))
          isFound = true
          break
       end
@@ -156,18 +160,27 @@ end
    T, offset
 end
 
-"General inquiry of element `tag` with `name` and `attr`."
-function getObjInfo(footer::EzXML.Node, name::String, tag::String, attr::String)
+function Base.findall(xpath::AbstractString, nodes::Vector{XML.LazyNode})
+   findall(x -> tag(x) == xpath, nodes)
+end
+
+function Base.findfirst(xpath::AbstractString, nodes::Vector{XML.LazyNode})
+   findfirst(x -> tag(x) == xpath, nodes)
+end
+
+"General inquiry of element `tag` with `tagname` and `attr`."
+function getObjInfo(ns::Vector{XML.LazyNode}, name::String, tagname::String, attr::String)
    local arraysize, datasize, datatype, vectorsize, offset
    isFound = false
 
-   for var in findall("//$tag", footer)
+   for i in findall(tagname, ns)
+      var = XML.attributes(ns[i])
       if var[attr] == name
          arraysize = Parsers.parse(Int, var["arraysize"])
          datasize = Parsers.parse(Int, var["datasize"])
          datatype = Symbol(var["datatype"])
          vectorsize = Parsers.parse(Int, var["vectorsize"])
-         offset = Parsers.parse(Int, nodecontent(var))
+         offset = Parsers.parse(Int, value(ns[i][1]))
          isFound = true
          break
       end
@@ -221,27 +234,29 @@ function load(file::AbstractString)
 
    footer = getfooter(fid)
 
-   ns = elements(footer)
+   #ns = elements(footer)
+   # May have extra allocation!
+   ns = children(footer[end])
 
    ibegin_, iend_ = zeros(Int, 6), zeros(Int, 6)
 
    for i in eachindex(ns)
-      if ns[i].name == "VARIABLE"
+      if tag(ns[i]) == "VARIABLE"
          if ibegin_[1] == 0 ibegin_[1] = i end
          iend_[1] = i
-      elseif ns[i].name == "PARAMETER"
+      elseif tag(ns[i]) == "PARAMETER"
          if ibegin_[2] == 0 ibegin_[2] = i end
          iend_[2] = i
-      elseif ns[i].name == "CELLSWITHBLOCKS"
+      elseif tag(ns[i]) == "CELLSWITHBLOCKS"
          if ibegin_[3] == 0 ibegin_[3] = i end
          iend_[3] = i
-      elseif ns[i].name == "BLOCKSPERCELL"
+      elseif tag(ns[i]) == "BLOCKSPERCELL"
          if ibegin_[4] == 0 ibegin_[4] = i end
          iend_[4] = i
-      elseif ns[i].name == "BLOCKVARIABLE"
+      elseif tag(ns[i]) == "BLOCKVARIABLE"
          if ibegin_[5] == 0 ibegin_[5] = i end
          iend_[5] = i
-      elseif ns[i].name == "BLOCKIDS"
+      elseif tag(ns[i]) == "BLOCKIDS"
          if ibegin_[6] == 0 ibegin_[6] = i end
          iend_[6] = i
       end
@@ -269,7 +284,7 @@ function load(file::AbstractString)
    cellid = getcellid(fid, n.var)
    cellindex = sortperm(cellid, alg=MergeSort)
 
-   ncells, block_size, coordmin, coordmax = readmesh(fid, footer)
+   ncells, block_size, coordmin, coordmax = readmesh(fid, ns)
 
    dcoord = ntuple(i -> (coordmax[i] - coordmin[i]) / ncells[i], Val(3))
 
@@ -284,11 +299,12 @@ function load(file::AbstractString)
    vmax = [1.0, 1.0, 1.0]
 
    for node in n.blockid
-      if haskey(node, "name")
+      at = attributes(node)
+      if haskey(at, "name")
          # VLSV 5.0 file with bounding box
-         popname = node["name"]
+         popname = at["name"]
 
-         vbox, nodeX, nodeY, nodeZ = readvmesh(fid, footer, popname)
+         vbox, nodeX, nodeY, nodeZ = readvmesh(fid, ns, popname)
 
          vblocks[1], vblocks[2], vblocks[3] = vbox[1], vbox[2], vbox[3]
          vblock_size[1], vblock_size[2], vblock_size[3] = vbox[4], vbox[5], vbox[6]
@@ -336,13 +352,13 @@ function load(file::AbstractString)
    # Obtain maximum refinement level
    maxamr = getmaxrefinement(cellid, ncells)
 
-   vars = [node["name"] for node in n.var]
+   vars = [attributes(node)["name"] for node in n.var]
 
    hasvdf = let
       if length(n.cellwithVDF) == 0
          false
       else
-         n.cellwithVDF[1]["arraysize"] != "0"
+         attributes(n.cellwithVDF[1])["arraysize"] != "0"
       end
    end
 
@@ -388,12 +404,13 @@ function readvariablemeta(meta::MetaVLSV, var::String)
       unit, variableLaTeX, unitLaTeX = units_predefined[varSym]
    elseif hasvariable(meta, var) # For Vlasiator 5 files, MetaVLSV is included
       for node in meta.nodeVLSV.var
-         if node["name"] == var
-            haskey(node, "unit") || break
-            unit = node["unit"]
-            unitLaTeX = node["unitLaTeX"]
-            variableLaTeX = node["variableLaTeX"]
-            unitConversion = node["unitConversion"]
+         at = attributes(node)
+         if at["name"] == var
+            haskey(at, "unit") || break
+            unit = at["unit"]
+            unitLaTeX = at["unitLaTeX"]
+            variableLaTeX = at["variableLaTeX"]
+            unitConversion = at["unitConversion"]
          end
       end
    end
@@ -401,11 +418,11 @@ function readvariablemeta(meta::MetaVLSV, var::String)
    VarInfo(unit, unitLaTeX, variableLaTeX, unitConversion)
 end
 
-@inline function readcoords(fid::IOStream, footer::EzXML.Node, qstring::String)
-   node = findfirst(qstring, footer)
+@inline function readcoords(fid::IOStream, ns::Vector{XML.LazyNode}, qstring::String)
+   node = ns[findfirst(qstring, ns)]
 
-   arraysize = Parsers.parse(Int, node["arraysize"])
-   offset = Parsers.parse(Int, nodecontent(node))
+   arraysize = Parsers.parse(Int, attributes(node)["arraysize"])
+   offset = Parsers.parse(Int, value(node[1]))
 
    # Warning: it may be Float32 in Vlasiator
    coord = Vector{Float64}(undef, arraysize)
@@ -415,14 +432,15 @@ end
    coord
 end
 
-function readvcoords(fid::IOStream, footer::EzXML.Node, species::String, qstring::String)
+function readvcoords(fid::IOStream, ns::Vector{XML.LazyNode}, species::String, qstring::String)
    local coord
-   ns = findall(qstring, footer)
+   is = findall(qstring, ns)
 
-   for i in reverse(eachindex(ns))
-      if ns[i]["mesh"] == species
-         arraysize = Parsers.parse(Int, ns[i]["arraysize"])
-         offset = Parsers.parse(Int, nodecontent(ns[i]))
+   for i in reverse(is)
+      at = attributes(ns[i])
+      if at["mesh"] == species
+         arraysize = Parsers.parse(Int, at["arraysize"])
+         offset = Parsers.parse(Int, value(ns[i][1]))
          # Warning: it may be Float32 in Vlasiator
          coord = Vector{Float64}(undef, arraysize)
          seek(fid, offset)
@@ -435,18 +453,18 @@ function readvcoords(fid::IOStream, footer::EzXML.Node, species::String, qstring
 end
 
 "Return spatial mesh information."
-function readmesh(fid::IOStream, footer::EzXML.Node)
+function readmesh(fid::IOStream, ns::Vector{XML.LazyNode})
    # Assume SpatialGrid and FsGrid follows Vlasiator 5 standard
-   node = findfirst("//MESH_BBOX", footer)
-   offset = Parsers.parse(Int, nodecontent(node))
+   node = ns[findfirst("MESH_BBOX", ns)]
+   offset = Parsers.parse(Int, value(node[1]))
 
    bbox = Vector{Int}(undef, 6)
    seek(fid, offset)
    read!(fid, bbox)
 
-   nodeX = readcoords(fid, footer, "//MESH_NODE_CRDS_X")
-   nodeY = readcoords(fid, footer, "//MESH_NODE_CRDS_Y")
-   nodeZ = readcoords(fid, footer, "//MESH_NODE_CRDS_Z")
+   nodeX = readcoords(fid, ns, "MESH_NODE_CRDS_X")
+   nodeY = readcoords(fid, ns, "MESH_NODE_CRDS_Y")
+   nodeZ = readcoords(fid, ns, "MESH_NODE_CRDS_Z")
 
    @inbounds ncells = (bbox[1], bbox[2], bbox[3])
    @inbounds block_size = (bbox[4], bbox[5], bbox[6])
@@ -457,23 +475,24 @@ function readmesh(fid::IOStream, footer::EzXML.Node)
 end
 
 "Return velocity mesh information."
-function readvmesh(fid::IOStream, footer::EzXML.Node, species::String)
-   ns = findall("//MESH_BBOX", footer)
+function readvmesh(fid::IOStream, ns::Vector{XML.LazyNode}, species::String)
+   is = findall("MESH_BBOX", ns)
 
    bbox = Vector{Int}(undef, 6)
 
-   for i in reverse(eachindex(ns))
-      if ns[i]["mesh"] == species
-         offset = Parsers.parse(Int, nodecontent(ns[i]))
+   for i in reverse(is)
+      at = attributes(ns[i])
+      if at["mesh"] == species
+         offset = Parsers.parse(Int, value(ns[i][1]))
          seek(fid, offset)
          read!(fid, bbox)
          break
       end
    end
 
-   nodeX = readvcoords(fid, footer, species, "//MESH_NODE_CRDS_X")
-   nodeY = readvcoords(fid, footer, species, "//MESH_NODE_CRDS_Y")
-   nodeZ = readvcoords(fid, footer, species, "//MESH_NODE_CRDS_Z")
+   nodeX = readvcoords(fid, ns, species, "MESH_NODE_CRDS_X")
+   nodeY = readvcoords(fid, ns, species, "MESH_NODE_CRDS_Y")
+   nodeZ = readvcoords(fid, ns, species, "MESH_NODE_CRDS_Z")
 
    bbox, nodeX, nodeY, nodeZ
 end
@@ -651,7 +670,7 @@ end
 @inline @Base.propagate_inbounds Base.getindex(meta::MetaVLSV, key::String) =
    readvariable(meta, key)
 
-@inline function getcellid(fid::IOStream, nodevar::AbstractVector{EzXML.Node})
+@inline function getcellid(fid::IOStream, nodevar::NodeVector)
    _, offset, asize, _, _ = getvarinfo(nodevar, "CellID")
    cellid = mmap(fid, Vector{Int}, asize, offset)
 end
@@ -665,7 +684,9 @@ Multi-threaded extraction of `var` at a fixed cell ID `cid` from `files`. This a
 function extractsat(files::AbstractVector{String}, var::String, cid::Int)
    v = open(files[1], "r") do fid
       footer = getfooter(fid)
-      nodevar = findall("//VARIABLE", footer)
+      ns = children(footer[end])
+      is = findall("VARIABLE", ns)
+      nodevar = @view ns[is[1]:is[end]]
       T, _, _, _, vsize = getvarinfo(nodevar, var)
 
       Array{T,2}(undef, vsize, length(files))
@@ -674,7 +695,9 @@ function extractsat(files::AbstractVector{String}, var::String, cid::Int)
    Threads.@threads for i in eachindex(files)
       fid = open(files[i], "r")
       footer = getfooter(fid)
-      nodevar = findall("//VARIABLE", footer)
+      ns = children(footer[end])
+      is = findall("VARIABLE", ns)
+      nodevar = @view ns[is[1]:is[end]]
       cellid = getcellid(fid, nodevar)
       c_ = findfirst(isequal(cid), cellid)
       _, offset, _, dsize, vsize = getvarinfo(nodevar, var)
@@ -783,7 +806,7 @@ Check if the VLSV file associated with `meta` contains a variable `var`.
 hasvariable(meta::MetaVLSV, var::String) = hasname(meta.nodeVLSV.var, var)
 
 "Check if the XML nodes `ns` contain a node of `name`."
-hasname(ns::NodeVector, name::String) = any(n -> n["name"] == name, ns)
+hasname(ns::NodeVector, name::String) = any(n -> attributes(n)["name"] == name, ns)
 
 """
     ndims(meta::MetaVLSV) -> Int
@@ -810,9 +833,10 @@ function readvcells(meta::MetaVLSV, cid::Int; species::String="proton")
 
    let cellsWithVDF, nblock_C
       for node in nodeVLSV.cellwithVDF
-         if node["name"] == species
-            asize = Parsers.parse(Int, node["arraysize"])
-            offset = Parsers.parse(Int, nodecontent(node))
+         at = attributes(node)
+         if at["name"] == species
+            asize = Parsers.parse(Int, at["arraysize"])
+            offset = Parsers.parse(Int, value(node[1]))
             cellsWithVDF = Vector{Int}(undef, asize)
             seek(fid, offset)
             read!(fid, cellsWithVDF)
@@ -821,10 +845,11 @@ function readvcells(meta::MetaVLSV, cid::Int; species::String="proton")
       end
 
       for node in nodeVLSV.cellblocks
-         if node["name"] == species
-            asize = Parsers.parse(Int, node["arraysize"])
-            dsize = Parsers.parse(Int, node["datasize"])
-            offset = Parsers.parse(Int, nodecontent(node))
+         at = attributes(node)
+         if at["name"] == species
+            asize = Parsers.parse(Int, at["arraysize"])
+            dsize = Parsers.parse(Int, at["datasize"])
+            offset = Parsers.parse(Int, value(node[1]))
             nblock_C = dsize == 4 ?
                Vector{Int32}(undef, asize) : Vector{Int}(undef, asize)
             seek(fid, offset)
@@ -851,10 +876,11 @@ function readvcells(meta::MetaVLSV, cid::Int; species::String="proton")
    local dsize, vsize, offset
    # Read in avgs
    for node in nodeVLSV.blockvar
-      if node["name"] == species
-         dsize = Parsers.parse(Int, node["datasize"])
-         vsize = Parsers.parse(Int, node["vectorsize"])
-         offset = Parsers.parse(Int, nodecontent(node))
+      at = attributes(node)
+      if at["name"] == species
+         dsize = Parsers.parse(Int, at["datasize"])
+         vsize = Parsers.parse(Int, at["vectorsize"])
+         offset = Parsers.parse(Int, value(node[1]))
          break
       end
    end
@@ -867,9 +893,10 @@ function readvcells(meta::MetaVLSV, cid::Int; species::String="proton")
 
    # Read in block IDs
    for node in nodeVLSV.blockid
-      if node["name"] == species
-         dsize = Parsers.parse(Int, node["datasize"])
-         offset = Parsers.parse(Int, nodecontent(node))
+      at = attributes(node)
+      if at["name"] == species
+         dsize = Parsers.parse(Int, at["datasize"])
+         offset = Parsers.parse(Int, value(node[1]))
          break
       end
    end

--- a/src/vlsv/vlsvreader.jl
+++ b/src/vlsv/vlsvreader.jl
@@ -1,6 +1,6 @@
 # VLSV reader in Julia
 
-const NodeVector = SubArray{XML.LazyNode, 1, Vector{XML.LazyNode}, Tuple{UnitRange{Int64}},
+const NodeVector = SubArray{LazyNode, 1, Vector{LazyNode}, Tuple{UnitRange{Int64}},
    true}
 
 "Velocity mesh information."
@@ -96,7 +96,6 @@ end
    # Obtain the offset of the XML
    offset = read(fid, Int)
    seek(fid, offset)
-   #footer = read(fid, String) |> parsexml |> root
    str = read(fid, String)
    footer = parse(str, LazyNode)
 end
@@ -119,7 +118,7 @@ function getvarinfo(nodevar::NodeVector, name::String)
    isFound = false
 
    for nv in nodevar
-      var = XML.attributes(nv)
+      var = attributes(nv)
       if var["name"] == name
          arraysize = Parsers.parse(Int, var["arraysize"])
          datasize = Parsers.parse(Int, var["datasize"])
@@ -143,7 +142,7 @@ end
    isFound = false
 
    for p in nodeparam
-      param = XML.attributes(p)
+      param = attributes(p)
       if param["name"] == name
          datasize = Parsers.parse(Int, param["datasize"])
          datatype = Symbol(param["datatype"])
@@ -160,21 +159,21 @@ end
    T, offset
 end
 
-function Base.findall(xpath::AbstractString, nodes::Vector{XML.LazyNode})
+function Base.findall(xpath::AbstractString, nodes::Vector{LazyNode})
    findall(x -> tag(x) == xpath, nodes)
 end
 
-function Base.findfirst(xpath::AbstractString, nodes::Vector{XML.LazyNode})
+function Base.findfirst(xpath::AbstractString, nodes::Vector{LazyNode})
    findfirst(x -> tag(x) == xpath, nodes)
 end
 
 "General inquiry of element `tag` with `tagname` and `attr`."
-function getObjInfo(ns::Vector{XML.LazyNode}, name::String, tagname::String, attr::String)
+function getObjInfo(ns::Vector{LazyNode}, name::String, tagname::String, attr::String)
    local arraysize, datasize, datatype, vectorsize, offset
    isFound = false
 
    for i in findall(tagname, ns)
-      var = XML.attributes(ns[i])
+      var = attributes(ns[i])
       if var[attr] == name
          arraysize = Parsers.parse(Int, var["arraysize"])
          datasize = Parsers.parse(Int, var["datasize"])
@@ -233,9 +232,6 @@ function load(file::AbstractString)
    fid = open(file, "r")
 
    footer = getfooter(fid)
-
-   #ns = elements(footer)
-   # May have extra allocation!
    ns = children(footer[end])
 
    ibegin_, iend_ = zeros(Int, 6), zeros(Int, 6)
@@ -418,7 +414,7 @@ function readvariablemeta(meta::MetaVLSV, var::String)
    VarInfo(unit, unitLaTeX, variableLaTeX, unitConversion)
 end
 
-@inline function readcoords(fid::IOStream, ns::Vector{XML.LazyNode}, qstring::String)
+@inline function readcoords(fid::IOStream, ns::Vector{LazyNode}, qstring::String)
    node = ns[findfirst(qstring, ns)]
 
    arraysize = Parsers.parse(Int, attributes(node)["arraysize"])
@@ -432,7 +428,7 @@ end
    coord
 end
 
-function readvcoords(fid::IOStream, ns::Vector{XML.LazyNode}, species::String, qstring::String)
+function readvcoords(fid::IOStream, ns::Vector{LazyNode}, species::String, qstring::String)
    local coord
    is = findall(qstring, ns)
 
@@ -453,7 +449,7 @@ function readvcoords(fid::IOStream, ns::Vector{XML.LazyNode}, species::String, q
 end
 
 "Return spatial mesh information."
-function readmesh(fid::IOStream, ns::Vector{XML.LazyNode})
+function readmesh(fid::IOStream, ns::Vector{LazyNode})
    # Assume SpatialGrid and FsGrid follows Vlasiator 5 standard
    node = ns[findfirst("MESH_BBOX", ns)]
    offset = Parsers.parse(Int, value(node[1]))
@@ -475,7 +471,7 @@ function readmesh(fid::IOStream, ns::Vector{XML.LazyNode})
 end
 
 "Return velocity mesh information."
-function readvmesh(fid::IOStream, ns::Vector{XML.LazyNode}, species::String)
+function readvmesh(fid::IOStream, ns::Vector{LazyNode}, species::String)
    is = findall("MESH_BBOX", ns)
 
    bbox = Vector{Int}(undef, 6)

--- a/src/vlsv/vlsvreader.jl
+++ b/src/vlsv/vlsvreader.jl
@@ -1,6 +1,6 @@
 # VLSV reader in Julia
 
-const NodeVector = SubArray{LazyNode, 1, Vector{LazyNode}, Tuple{UnitRange{Int64}},
+const NodeVector = SubArray{Node, 1, Vector{Node}, Tuple{UnitRange{Int64}},
    true}
 
 "Velocity mesh information."
@@ -97,7 +97,7 @@ end
    offset = read(fid, Int)
    seek(fid, offset)
    str = read(fid, String)
-   footer = parse(str, LazyNode)
+   footer = parse(str, Node)
 end
 
 @inline function getdatatype(datatype::Symbol, datasize::Int)
@@ -159,16 +159,16 @@ end
    T, offset
 end
 
-function Base.findall(xpath::AbstractString, nodes::Vector{LazyNode})
+function Base.findall(xpath::AbstractString, nodes::Vector{Node})
    findall(x -> tag(x) == xpath, nodes)
 end
 
-function Base.findfirst(xpath::AbstractString, nodes::Vector{LazyNode})
+function Base.findfirst(xpath::AbstractString, nodes::Vector{Node})
    findfirst(x -> tag(x) == xpath, nodes)
 end
 
 "General inquiry of element `tag` with `tagname` and `attr`."
-function getObjInfo(ns::Vector{LazyNode}, name::String, tagname::String, attr::String)
+function getObjInfo(ns::Vector{Node}, name::String, tagname::String, attr::String)
    local arraysize, datasize, datatype, vectorsize, offset
    isFound = false
 
@@ -414,7 +414,7 @@ function readvariablemeta(meta::MetaVLSV, var::String)
    VarInfo(unit, unitLaTeX, variableLaTeX, unitConversion)
 end
 
-@inline function readcoords(fid::IOStream, ns::Vector{LazyNode}, qstring::String)
+@inline function readcoords(fid::IOStream, ns::Vector{Node}, qstring::String)
    node = ns[findfirst(qstring, ns)]
 
    arraysize = Parsers.parse(Int, attributes(node)["arraysize"])
@@ -428,7 +428,7 @@ end
    coord
 end
 
-function readvcoords(fid::IOStream, ns::Vector{LazyNode}, species::String, qstring::String)
+function readvcoords(fid::IOStream, ns::Vector{Node}, species::String, qstring::String)
    local coord
    is = findall(qstring, ns)
 
@@ -449,7 +449,7 @@ function readvcoords(fid::IOStream, ns::Vector{LazyNode}, species::String, qstri
 end
 
 "Return spatial mesh information."
-function readmesh(fid::IOStream, ns::Vector{LazyNode})
+function readmesh(fid::IOStream, ns::Vector{Node})
    # Assume SpatialGrid and FsGrid follows Vlasiator 5 standard
    node = ns[findfirst("MESH_BBOX", ns)]
    offset = Parsers.parse(Int, value(node[1]))
@@ -471,7 +471,7 @@ function readmesh(fid::IOStream, ns::Vector{LazyNode})
 end
 
 "Return velocity mesh information."
-function readvmesh(fid::IOStream, ns::Vector{LazyNode}, species::String)
+function readvmesh(fid::IOStream, ns::Vector{Node}, species::String)
    is = findall("MESH_BBOX", ns)
 
    bbox = Vector{Int}(undef, 6)

--- a/src/vlsv/vlsvutility.jl
+++ b/src/vlsv/vlsvutility.jl
@@ -1373,9 +1373,9 @@ function write_vtk(meta::MetaVLSV; vars::Vector{String}=[""], ascii::Bool=false,
       # Generate vthb file
       filemeta = outdir*meta.name[1:end-4]*"vthb"
 
-      doc = XML.Document()
+      doc = Document()
 
-      elm = XML.Element("VTKFile";
+      elm = Element("VTKFile";
          type="vtkOverlappingAMR",
          version="1.1",
          byte_order="LittleEndian", # x86
@@ -1384,7 +1384,7 @@ function write_vtk(meta::MetaVLSV; vars::Vector{String}=[""], ascii::Bool=false,
       push!(doc, elm)
 
       origin = @sprintf "%f %f %f" coordmin[1] coordmin[2] coordmin[3]
-      xamr = XML.Element("vtkOverlappingAMR";
+      xamr = Element("vtkOverlappingAMR";
          origin=origin,
          grid_description="XYZ"
       )
@@ -1392,7 +1392,7 @@ function write_vtk(meta::MetaVLSV; vars::Vector{String}=[""], ascii::Bool=false,
 
       @inbounds for i = 0:maxamr
          spacing_str = @sprintf "%f %f %f" dcoord[1]/2^i dcoord[2]/2^i dcoord[3]/2^i
-         xBlock = XML.Element("Block";
+         xBlock = Element("Block";
             level=string(i),
             spacing=spacing_str
          )
@@ -1401,7 +1401,7 @@ function write_vtk(meta::MetaVLSV; vars::Vector{String}=[""], ascii::Bool=false,
          amr_box = (0, ncells[1]*2^i-1, 0, ncells[2]*2^i-1, 0, ncells[3]*2^i-1)
          box_str = @sprintf("%d %d %d %d %d %d", amr_box[1], amr_box[2], amr_box[3],
             amr_box[4], amr_box[5], amr_box[6])
-         xDataSet = XML.Element("DataSet";
+         xDataSet = Element("DataSet";
             index="0",
             amr_box=box_str,
             file=filedata[i+1]
@@ -1409,7 +1409,7 @@ function write_vtk(meta::MetaVLSV; vars::Vector{String}=[""], ascii::Bool=false,
          push!(xBlock, xDataSet)
       end
 
-      XML.write(filemeta, doc)
+      write(filemeta, doc)
    end
 
    return
@@ -1518,7 +1518,7 @@ function write_vlsv(filein::AbstractString, fileout::AbstractString,
       [offset, [sizeof(newvars[i][1]) for i in eachindex(newvars)[1:end-1]]...])
    # Create new children for footer
    for i in eachindex(newvars, offsets)
-      elm = XML.Element("VARIABLE", string(offsets[i]);
+      elm = Element("VARIABLE", string(offsets[i]);
          arraysize=string(length(newvars[i][1])),
          datasize=string(sizeof(eltype(newvars[i][1]))),
          datatype=
@@ -1557,7 +1557,7 @@ function write_vlsv(filein::AbstractString, fileout::AbstractString,
       for var in newvars
          write(io, var[1])
       end
-      XML.write(io, footer)
+      write(io, footer)
    end
 
    return

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,8 @@ end
    if group in (:read, :all)
       @testset "Reading files" begin
          _, offset, _, _, _ = let footer = Vlasiator.getfooter(meta1.fid)
-            Vlasiator.getObjInfo(footer, "time", "PARAMETER", "name")
+            ns = Vlasiator.XML.children(footer[end])
+            Vlasiator.getObjInfo(ns, "time", "PARAMETER", "name")
          end
          @test offset == 264
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ end
    if group in (:read, :all)
       @testset "Reading files" begin
          _, offset, _, _, _ = let footer = Vlasiator.getfooter(meta1.fid)
-            ns = Vlasiator.XML.children(footer[end])
+            ns = Vlasiator.children(footer[end])
             Vlasiator.getObjInfo(ns, "time", "PARAMETER", "name")
          end
          @test offset == 264


### PR DESCRIPTION
This is an attempt to replace EzXML with XML. XML.jl provides two basic structures: `Node` and `LazyNode`. `LazyNode` is faster in reading the meta data, but `Node` uses less memory and is slightly faster in reading variables.