### PR TITLE
Check mmap alignment

### DIFF
--- a/src/vlsv/vlsvreader.jl
+++ b/src/vlsv/vlsvreader.jl
@@ -207,7 +207,7 @@ end
    ::Val{true}) where T
    w =
       if offset % dsize == 0
-         mmap(fid, Vector{T}, dsize*asize, offset)
+         mmap(fid, Vector{T}, asize, offset)
       else
          a = mmap(fid, Vector{UInt8}, dsize*asize, offset)
          reinterpret(T, a)

--- a/src/vlsv/vlsvreader.jl
+++ b/src/vlsv/vlsvreader.jl
@@ -616,12 +616,8 @@ end
    nid::Int, offset::Int, asize::Int, dsize::Int, vsize::Int)::Array{T} where T
    v = vsize == 1 ? Vector{T}(undef, nid) : Array{T,2}(undef, vsize, nid)
 
-   if offset % dsize == 0
-      w = mmap(fid, Array{T,2}, (vsize, asize), offset)
-   else
-      a = mmap(fid, Vector{UInt8}, dsize*vsize*asize, offset)
-      w = reshape(reinterpret(T, a), vsize, asize)
-   end
+   a = mmap(fid, Vector{UInt8}, dsize*vsize*asize, offset)
+   w = reshape(reinterpret(T, a), vsize, asize)
 
    _fillv!(v, w, celldict, ids)
 

--- a/src/vlsv/vlsvreader.jl
+++ b/src/vlsv/vlsvreader.jl
@@ -227,7 +227,7 @@ end
    vsize::Int, ::Val{true}) where T
    w =
       if offset % dsize == 0
-         mmap(fid, Array{T,2}, (vsize, asize), offset)
+         mmap(fid, Array{T, 2}, (vsize, asize), offset)
       else
          a = mmap(fid, Vector{UInt8}, dsize*vsize*asize, offset)
          reshape(reinterpret(T, a), vsize, asize)
@@ -555,7 +555,7 @@ function readvariable(meta::MetaVLSV, var::String, sorted::Bool=true, usemmap::B
       v = raw
    end
 
-   return v::Union{Array, Base.ReinterpretArray}
+   return v::Union{Array, Base.ReinterpretArray, Base.ReshapedArray}
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,6 +69,7 @@ end
          @test meta.cellindex == [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
          # unsorted ID + mmap
          @test readvariable(meta, "CellID", false, true) == 10:-1:1
+         @test size(readvariable(meta, "proton/vg_v", false, true)) == (3, 10)
          # sorted var by default
          @test meta["vg_boundarytype"] == [4, 4, 1, 1, 1, 1, 1, 1, 3, 3]
          # ID finding (noAMR)


### PR DESCRIPTION
Check `mmap` alignment for avoiding reinterpret in some cases.